### PR TITLE
fix: Disable buildSearchableOptions and some small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,6 @@ Semgrep supports 30+ languages.
 
 ## Support
 
-If you need our support, join the [Semgrep community Slack workspace](http://go.semgrep.dev/slack) and tell us about any problems you encountered.
+If you need our support, join the [Semgrep community Slack workspace](https://go.semgrep.dev/slack) and tell us about any problems you encountered.
 
 <!-- Plugin description end -->

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,11 @@ koverReport {
 }
 
 tasks {
+
+    buildSearchableOptions {
+        enabled = false
+    }
+
     wrapper {
         gradleVersion = properties("gradleVersion").get()
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ pluginGroup=com.semgrep.idea
 pluginName=semgrep
 pluginRepositoryUrl=https://github.com/returntocorp/semgrep-intellij
 # SemVer format -> https://semver.org
-pluginVersion=0.1.0
+pluginVersion=0.1.1
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild=232
 pluginUntilBuild=232.*

--- a/src/main/kotlin/com/semgrep/idea/lsp/SemgrepInstaller.kt
+++ b/src/main/kotlin/com/semgrep/idea/lsp/SemgrepInstaller.kt
@@ -40,7 +40,7 @@ object SemgrepInstaller {
     fun semgrepInstalled(): Boolean {
         val defaultPath = SemgrepPluginSettings().path
         val state = AppState.getInstance().appSettings
-        return state.path != defaultPath && which(defaultPath) != null
+        return state.path != defaultPath || which(defaultPath) != null
     }
 
     fun getCliVersion(): SemVer? {


### PR DESCRIPTION
the task `buildSearchableOptions` fails on intellij platforms >= 2023.2 (which is the min version needed for LSP) while verifying the plugin. I think this produces searchable tags for the plugin. I confirmed on a completely new plugin that this still happens, and tried against multiple JDKs. I also found a few open bug reports, so I'm going to just say disable this for now so we can take advantage of the github workflows, and plugin verifyer.

Also changed a link to be secure, and changed an and to an or.