### PR TITLE
feat: consume new login flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased]
 
+- Some internals API updates to authentication. The minimum supported Semgrep
+  CLI version is now 1.101.0
+
 ## [0.4.0] - 2024-11-27
 
 - Bumped LSP.js version

--- a/src/main/kotlin/com/semgrep/idea/actions/LoginAction.kt
+++ b/src/main/kotlin/com/semgrep/idea/actions/LoginAction.kt
@@ -10,10 +10,10 @@ import kotlinx.coroutines.launch
 class LoginAction(private val notification: Notification? = null) : LspAction("Sign In with Semgrep") {
     override fun actionPerformed(lspServer: LspServer) {
         SemgrepService.getInstance(lspServer.project).cs.launch {
-            val loginResult = lspServer.sendRequest { (it as SemgrepLanguageServer).login() }
+            val loginResult = lspServer.sendRequest { (it as SemgrepLanguageServer).loginStart() }
                 ?: return@launch
             BrowserUtil.browse(loginResult.url)
-            lspServer.sendNotification { (it as SemgrepLanguageServer).loginFinish(loginResult) }
+            lspServer.sendRequest { (it as SemgrepLanguageServer).loginFinish(loginResult) }
             notification?.expire()
         }
     }

--- a/src/main/kotlin/com/semgrep/idea/lsp/SemgrepLanguageServer.kt
+++ b/src/main/kotlin/com/semgrep/idea/lsp/SemgrepLanguageServer.kt
@@ -8,16 +8,17 @@ import java.util.concurrent.CompletableFuture
 interface SemgrepLanguageServer : LanguageServer {
 
     // Requests
-    @JsonRequest("semgrep/login")
-    fun login(params:List<Void> = emptyList()): CompletableFuture<LoginResult>
+    @JsonRequest("semgrep/loginStart")
+    fun loginStart(params:List<Void> = emptyList()): CompletableFuture<LoginResult>
 
     @JsonRequest("semgrep/loginStatus")
     fun loginStatus(params:List<Void> = emptyList()): CompletableFuture<LoginStatusResult>
 
-    // Notifications
-    @JsonNotification("semgrep/loginFinish")
-    fun loginFinish(params: LoginResult)
+    @JsonRequest("semgrep/loginFinish")
+    fun loginFinish(params: LoginResult): CompletableFuture<LoginStatusResult>
 
+    // Notifications
+    //
     // We need the List<Void> because of a bug in lsp4j
     // when params are not defined, they get set to null (instead of removing the field)
     // and the server throws an exception


### PR DESCRIPTION
This should let us avoid stale state caused by the prior implementation, which handled the "finish" step as a notification, rather than as a request. We currently don't put this in an environment like we do in VSCode, since we don't have a similar display here, but this change would make it easy to do so in the future.

Do not merge without corresponding CLI API version.