### PR TITLE
fix(windows): switch to using native Semgrep

### DIFF
--- a/src/main/kotlin/com/semgrep/idea/lsp/SemgrepInstaller.kt
+++ b/src/main/kotlin/com/semgrep/idea/lsp/SemgrepInstaller.kt
@@ -75,7 +75,8 @@ object SemgrepInstaller {
     }
 
     fun which(binary: String): String? {
-        val cmd = GeneralCommandLine("which", binary)
+        val command = if (isWindows()) "where" else "which"
+        val cmd = GeneralCommandLine(command, binary)
 
         val process = cmd.createProcess()
         process.waitFor()

--- a/src/main/kotlin/com/semgrep/idea/lsp/SemgrepLspServerDescriptor.kt
+++ b/src/main/kotlin/com/semgrep/idea/lsp/SemgrepLspServerDescriptor.kt
@@ -57,7 +57,10 @@ class SemgrepLspServerDescriptor(project: Project) : ProjectWideLspServerDescrip
         return commandLine.apply {
             withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE)
             withCharset(Charsets.UTF_8)
-
+            if (SemgrepInstaller.isWindows()) {
+                // TODO: Remove when Semgrep is supported on Windows
+                withEnvironment("SEMGREP_FORCE_INSTALL", "1")
+            }
         }
     }
 

--- a/src/main/kotlin/com/semgrep/idea/settings/LspSettings.kt
+++ b/src/main/kotlin/com/semgrep/idea/settings/LspSettings.kt
@@ -18,7 +18,7 @@ data class SemgrepLspSettings(
     var doHover: Boolean = false,
     var metrics: Metrics = Metrics(),
     var pro_intrafile: Boolean = false,
-    var useJS: Boolean = System.getProperty("os.name").lowercase(Locale.getDefault()).contains("win"),
+    var useJS: Boolean = false,
     var stackSizeJS: Int = 1024 * 1024,
     var heapSizeJS: Int = 4096,
 ) {


### PR DESCRIPTION
This commit switches the plugin to run using the native Semgrep
executable on Windows, from the previous used lspjs one. It also
sets the SEMGREP_FORCE_INSTALL environment variable currently
required on Windows. We switch to using "where" on Windows,
instead of "which" to find the semgrep executable.

Test plan:

- Test the plugin on a system with semgrep already installed.

PR checklist:

- [x] Purpose of the code is [evident to future readers](https://semgrep.dev/docs/contributing/contributing-code/#explaining-code)
- [x] Tests included or PR comment includes a reproducible test plan
- [x] Documentation is up-to-date
- [x] A changelog entry was for any user-facing change
- [x] Change has no security implications (otherwise, ping security team)
