### PR TITLE
fix(windows): allow installing semgrep on Windows if not found

### DIFF
--- a/src/main/kotlin/com/semgrep/idea/lsp/SemgrepInstaller.kt
+++ b/src/main/kotlin/com/semgrep/idea/lsp/SemgrepInstaller.kt
@@ -1,8 +1,14 @@
 package com.semgrep.idea.lsp
 
 import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.execution.process.CapturingProcessHandler
+import com.intellij.execution.process.ProcessOutput
 import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreter
 import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreterManager
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.platform.lsp.api.LspServerManager
@@ -27,18 +33,37 @@ object SemgrepInstaller {
         }
 
         fun install(project: Project) {
-            val cmd = GeneralCommandLine(binary).withParameters(*args)
-            val process = cmd.createProcess()
-            val ret = process.waitFor()
-            val out = process.inputStream.bufferedReader().readText()
-            val semgrepNotifier = SemgrepNotifier(project)
-            if (ret == 0) {
-                semgrepNotifier.notifyInstallSuccess()
-                LspServerManager.getInstance(project)
-                    .stopAndRestartIfNeeded(SemgrepLspServerSupportProvider::class.java)
-            } else {
-                semgrepNotifier.notifyInstallFailure(out, ret)
-            }
+            // Run the whole operation in an IntelliJ background task
+            ProgressManager.getInstance().run(object : Task.Backgroundable(
+                project,
+                "Installing Semgrep CLI",
+		true, /* canBeCancelled */
+            ) {
+                override fun run(indicator: ProgressIndicator) {
+                    indicator.text = "Running $binary ${args.joinToString(" ")}"
+
+                    val cmd = GeneralCommandLine(binary).withParameters(*args).apply {
+                        isRedirectErrorStream = true
+                        withCharset(Charsets.UTF_8)
+                    }
+
+                    // CapturingProcessHandler consumes output while the process is alive
+                    val handler = CapturingProcessHandler(cmd)
+                    val output: ProcessOutput = handler.runProcess(300000)  // timeout in 5 minutes
+
+                    // Switch back to EDT for any UI updates / notifications
+                    ApplicationManager.getApplication().invokeLater {
+                        val notifier = SemgrepNotifier(project)
+                        if (output.exitCode == 0) {
+                            notifier.notifyInstallSuccess()
+                            LspServerManager.getInstance(project)
+                                .stopAndRestartIfNeeded(SemgrepLspServerSupportProvider::class.java)
+                        } else {
+                            notifier.notifyInstallFailure(output.stdout.trim(), output.exitCode)
+                        }
+                    }
+                }
+            })
         }
     }
 

--- a/src/main/kotlin/com/semgrep/idea/lsp/SemgrepInstaller.kt
+++ b/src/main/kotlin/com/semgrep/idea/lsp/SemgrepInstaller.kt
@@ -75,7 +75,8 @@ object SemgrepInstaller {
     }
 
     fun which(binary: String): String? {
-        val cmd = GeneralCommandLine("which", binary)
+        val command = if (isWindows()) "where" else "which"
+        val cmd = GeneralCommandLine(command, binary)
 
         val process = cmd.createProcess()
         process.waitFor()

--- a/src/main/kotlin/com/semgrep/idea/lsp/SemgrepInstaller.kt
+++ b/src/main/kotlin/com/semgrep/idea/lsp/SemgrepInstaller.kt
@@ -18,16 +18,16 @@ import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 
 object SemgrepInstaller {
-    enum class InstallOption(val binary: String, val installCommand: String) {
-        BREW("brew", "brew install semgrep"),
-        PIP("pip3", "pip3 install semgrep");
+    enum class InstallOption(val binary: String, vararg val args: String) {
+        BREW("brew", "install", "semgrep"),
+        PIP("pip3", "install", "semgrep");
 
         fun isInstalled(): Boolean {
             return which(binary) != null
         }
 
         fun install(project: Project) {
-            val cmd = GeneralCommandLine("sh", "-c", installCommand)
+            val cmd = GeneralCommandLine(binary).withParameters(*args)
             val process = cmd.createProcess()
             val ret = process.waitFor()
             val out = process.inputStream.bufferedReader().readText()

--- a/src/main/kotlin/com/semgrep/idea/lsp/SemgrepLspServerDescriptor.kt
+++ b/src/main/kotlin/com/semgrep/idea/lsp/SemgrepLspServerDescriptor.kt
@@ -57,7 +57,10 @@ class SemgrepLspServerDescriptor(project: Project) : ProjectWideLspServerDescrip
         return commandLine.apply {
             withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE)
             withCharset(Charsets.UTF_8)
-
+            if (SemgrepInstaller.isWindows()) {
+                // TODO: Remove when Semgrep is supported on Windows
+                withEnvironment("SEMGREP_FORCE_INSTALL", "1")
+            }
         }
     }
 

--- a/src/main/kotlin/com/semgrep/idea/settings/LspSettings.kt
+++ b/src/main/kotlin/com/semgrep/idea/settings/LspSettings.kt
@@ -18,7 +18,7 @@ data class SemgrepLspSettings(
     var doHover: Boolean = false,
     var metrics: Metrics = Metrics(),
     var pro_intrafile: Boolean = false,
-    var useJS: Boolean = System.getProperty("os.name").lowercase(Locale.getDefault()).contains("win"),
+    var useJS: Boolean = false,
     var stackSizeJS: Int = 1024 * 1024,
     var heapSizeJS: Int = 4096,
 ) {

--- a/src/main/kotlin/com/semgrep/idea/ui/SemgrepInstallBanner.kt
+++ b/src/main/kotlin/com/semgrep/idea/ui/SemgrepInstallBanner.kt
@@ -15,14 +15,12 @@ class SemgrepInstallBannerProvider : EditorNotifications.Provider<SemgrepInstall
 
     class SemgrepInstallBanner(project: Project) : EditorNotificationPanel(Status.Error) {
         init {
-            if (!SemgrepInstaller.isWindows()) {
-                val installOptions = SemgrepInstaller.getInstallOptions()
-                installOptions.forEach {
-                    createActionLabel("Install with ${it.name.lowercase()}") {
-                        it.install(project)
-                        AppState.getInstance().pluginState.handledInstallBanner = true
-                        EditorNotifications.getInstance(project).updateAllNotifications()
-                    }
+            val installOptions = SemgrepInstaller.getInstallOptions()
+            installOptions.forEach {
+                createActionLabel("Install with ${it.name.lowercase()}") {
+                    it.install(project)
+                    AppState.getInstance().pluginState.handledInstallBanner = true
+                    EditorNotifications.getInstance(project).updateAllNotifications()
                 }
             }
             createActionLabel("Ignore Extension") {
@@ -40,11 +38,7 @@ class SemgrepInstallBannerProvider : EditorNotifications.Provider<SemgrepInstall
         fileEditor: FileEditor,
         project: Project
     ): SemgrepInstallBanner? {
-        if (SemgrepInstaller.isWindows() || SemgrepInstaller.semgrepInstalled() || AppState.getInstance().pluginState.handledInstallBanner) {
-            return null
-        }
-        if (SemgrepInstaller.isWindows()) {
-            SemgrepNotifier(project).notifyWindowsNotSupported()
+        if (SemgrepInstaller.semgrepInstalled() || AppState.getInstance().pluginState.handledInstallBanner) {
             return null
         }
         return SemgrepInstallBanner(project)


### PR DESCRIPTION
This commit removes the checks to prevent displaying the option of
installing semgrep from pip on Windows. Also, we fix the installation
to invoke pip correctly, without depending on "sh".

Also, run the semgrep installation in a background task

Currently, if we try to install semgrep via pip or brew from the
notification bar, the installation freezes the IDE's UI. This commit
moves the installation to a background task which improves the UX!

NOTE: This PR is based on top of #131 