### PR TITLE
fix(windows): check for bash before setting up lspjs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,6 +67,18 @@ koverReport {
     }
 }
 
+
+fun isBashAvailable(): Boolean {
+    return try {
+        exec {
+            commandLine("bash", "--version")
+        }
+        true
+    } catch (_: Throwable) {
+        false
+    }
+}
+
 tasks {
 
     buildSearchableOptions {
@@ -111,18 +123,23 @@ tasks {
     prepareSandbox {
         notCompatibleWithConfigurationCache("Uses project copy")
         doLast {
-            exec {
-                commandLine(
-                    "./download-lspjs.sh",
-                    "Main.bc.js",
-                    "language-server-wasm.js",
-                    "semgrep-lsp-bindings.js",
-                    "semgrep-lsp.js"
-                )
-            }
-            copy {
-                from("${project.projectDir}/lspjs")
-                into("${destinationDir.path}/${intellij.pluginName.get()}/lspjs")
+            if (!isBashAvailable()) {
+                println("Warning: 'bash' is not available on your PATH. Skipping lspjs setup.")
+            } else {
+                exec {
+                    commandLine(
+                        "bash",
+                        "download-lspjs.sh",
+                        "Main.bc.js",
+                        "language-server-wasm.js",
+                        "semgrep-lsp-bindings.js",
+                        "semgrep-lsp.js"
+                    )
+                }
+                copy {
+                    from("${project.projectDir}/lspjs")
+                    into("${destinationDir.path}/${intellij.pluginName.get()}/lspjs")
+                }
             }
         }
     }


### PR DESCRIPTION
We currently use a bash script to download and setup lspjs. On Windows, bash
may not be installed or not on the PATH, which causes the gradle build to
crash. This commit explicitly checks for bash before trying to setup lspjs.
