### PR TITLE
ci: sign bump_version commits via `create-pull-request` [SEC-2047]

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   bump-version:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -12,9 +12,7 @@ jobs:
   bump-version:
     runs-on: ubuntu-20.04
     permissions:
-      id-token: write
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - name: Authenticate as semgrep-ide-plugins-release
         id: generate-token
@@ -22,9 +20,9 @@ jobs:
         with:
           app-id: ${{ vars.SEMGREP_IDE_PLUGINS_RELEASE_APP_ID }}
           private-key: ${{ secrets.SEMGREP_IDE_PLUGINS_RELEASE_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
-        with:
-          token: ${{ steps.generate-token.outputs.token }}
+
       - name: Update version
         env:
           SEMGREP_STATIC_VERSION: "release-${{ inputs.version }}"
@@ -34,39 +32,13 @@ jobs:
               exit 1
           fi
           echo "${SEMGREP_STATIC_VERSION}" > semgrep-version
-      - name: Commit and push
-        id: commit
-        env:
-          NEW_SEMGREP_VERSION: "${{ github.event.inputs.version }}"
-          GITHUB_ACTOR: "${{ github.actor }}"
-          GITHUB_RUN_ID: "${{ github.run_id }}"
-          GITHUB_RUN_ATTEMPT: "${{ github.run_attempt }}"
-        run: |
-          git config user.name "${GITHUB_ACTOR}"
-          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          BRANCH="gha/bump-version-${NEW_SEMGREP_VERSION}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          SUBJECT="Bump semgrep to ${NEW_SEMGREP_VERSION}"
-          git checkout -b "${BRANCH}"
-          git add .
-          git commit -m "${SUBJECT}"
-          git push --set-upstream origin "${BRANCH}"
-          echo "branch=${BRANCH}" >> "${GITHUB_OUTPUT}"
-          echo "subject=${SUBJECT}" >> "${GITHUB_OUTPUT}"
-      - name: Create PR
-        id: open-pr
-        env:
-          SOURCE: "${{ steps.commit.outputs.branch }}"
-          TARGET: "${{ github.event.repository.default_branch }}"
-          TITLE: "chore: Release Version ${{ inputs.version }}"
-          VERSION: "${{ inputs.version }}"
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          # check if the branch already has a pull request open
-          if gh pr list --head "${SOURCE}" | grep -vq "no pull requests"; then
-              # pull request already open
-              echo "pull request from SOURCE ${SOURCE} to TARGET ${TARGET} is already open";
-              echo "cancelling release"
-              exit 1
-          fi
-          # open new pull request with the body of from the local template.
-          gh pr create --title "${TITLE}" --body "Bump Semgrep Version to ${VERSION}" --base "${TARGET}" --head "${SOURCE}"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          sign-commits: true
+          branch: gha/bump-version-${{ inputs.version }}-${{ github.run_id }}-${{ github.run_attempt }}
+          commit-message: Bump semgrep to ${{ inputs.version }}
+          title: "chore: Release Version ${{ inputs.version }}"
+          body: Bump Semgrep Version to ${{ inputs.version }}

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -16,12 +16,12 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: Authenticate as semgrep-autoapprover
+      - name: Authenticate as semgrep-ide-plugins-release
         id: generate-token
         uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
-          app-id: ${{ secrets.SEMGREP_AUTOAPPROVER_APP_ID }}
-          private-key: ${{ secrets.SEMGREP_AUTOAPPROVER_PRIVATE_KEY }}
+          app-id: ${{ vars.SEMGREP_IDE_PLUGINS_RELEASE_APP_ID }}
+          private-key: ${{ secrets.SEMGREP_IDE_PLUGINS_RELEASE_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -16,7 +16,15 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v2
+      - name: Authenticate as semgrep-autoapprover
+        id: generate-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.SEMGREP_AUTOAPPROVER_APP_ID }}
+          private-key: ${{ secrets.SEMGREP_AUTOAPPROVER_PRIVATE_KEY }}
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
       - name: Update version
         env:
           SEMGREP_STATIC_VERSION: "release-${{ inputs.version }}"
@@ -51,7 +59,7 @@ jobs:
           TARGET: "${{ github.event.repository.default_branch }}"
           TITLE: "chore: Release Version ${{ inputs.version }}"
           VERSION: "${{ inputs.version }}"
-          GH_TOKEN: "${{ github.token }}"
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           # check if the branch already has a pull request open
           if gh pr list --head "${SOURCE}" | grep -vq "no pull requests"; then


### PR DESCRIPTION
## Problem

The default `secrets.GITHUB_TOKEN` runs as `github-actions[bot]`, and `git commit` from a runner produces unsigned commits.

## Solution

Use `create-pull-request` with `sign-commits: true`, authenticated as a new dedicated `semgrep-ide-plugins-release` app. With `sign-commits: true`, the action creates the commit via the GitHub API rather than `git commit`, which means GitHub signs it automatically and it shows as "Verified" — satisfying the ruleset without needing the app on a bypass list.

The hand-rolled `git config` / `git commit` / `git push` / `gh pr create` steps collapse into a single action invocation.
